### PR TITLE
Add getDisplayCutoutUnadjusted method to ignore density

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ Code example
 Here are some examples on how you can use this plugin
 
 ```js
+// Set the cutout mode:
 DisplayCutout.setDisplayCutout(displayCutoutMode,successFunction, errorFunction);
 
+// Get the display cutout (density adjusted):
 DisplayCutout.getDisplayCutout(successFunction, errorFunction);
 
+// Get the display cutout (raw pixels). Useful for canvas applications.
+DisplayCutout.getDisplayCutoutUnadjusted(successFunction, errorFunction);
 ```

--- a/src/android/CDVDisplayCutout.java
+++ b/src/android/CDVDisplayCutout.java
@@ -71,6 +71,9 @@ public class CDVDisplayCutout extends CordovaPlugin {
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, 0));
             return true;
         }
+	    
+        boolean densityAdjusted = args.optBoolean(0);
+	    
         Activity activity = cordova.getActivity();
         activity.runOnUiThread(new Runnable(){
             @Override
@@ -79,7 +82,7 @@ public class CDVDisplayCutout extends CordovaPlugin {
                     final WindowInsets insets = getInsets();
                     final DisplayCutout cutout = insets.getDisplayCutout();
 
-                    float dens = 1 / activity.getResources().getDisplayMetrics().density;
+                    float dens = densityAdjusted ? 1 / activity.getResources().getDisplayMetrics().density : 1;
                     float bottom = cutout != null ? (cutout.getSafeInsetBottom() * dens) : 0; 
                     float left = cutout != null ? (cutout.getSafeInsetLeft() * dens) : 0; 
                     float right = cutout != null ? (cutout.getSafeInsetRight() * dens) : 0; 

--- a/www/cutout.js
+++ b/www/cutout.js
@@ -7,11 +7,17 @@ var DisplayCutout = {
   LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER: 0x00000002,
   LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES: 0x00000001,
 
+  // Set the display cutout mode.
   setDisplayCutout: function (mode, success, error) {
     run(success, error, "DisplayCutouts", "setDisplayCutout", [mode || 0]);
   },
+  // Get the display coutout returning density adjusted pixels.
   getDisplayCutout: function (success, error) {
-    run(success, error, "DisplayCutouts", "getDisplayCutout");
+    run(success, error, "DisplayCutouts", "getDisplayCutout", true);
+  },
+  // Get the display coutout returning raw pixel values.
+  getDisplayCutoutUnadjusted: function (success, error) {
+    run(success, error, "DisplayCutouts", "getDisplayCutout", false);
   },
 };
 


### PR DESCRIPTION
My game engine (using canvas) needs raw pixel values. I added a new method (for backwards compatibility) to get the insets without multiplying by the density. Hope this is useful!

Tested this on an Android 12 device (Pixel 5).